### PR TITLE
Maven Central "501 HTTPS Required" Fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,12 @@
 buildscript {
     repositories {
-        mavenCentral()
+        maven {
+			name = "mavencentral"
+			url = "https://repo.maven.apache.org/maven2"
+		}
         maven {
             name = "forge"
-            url = "http://files.minecraftforge.net/maven"
+            url = "https://files.minecraftforge.net/maven"
         }
         maven {
             name = "sonatype"


### PR DESCRIPTION
This PR fixes an error with `build.gradle`, specifically maven central URL.

> Starting in January 2020, Gradle services will only serve requests made with HTTPS. From that point on, all requests made with HTTP will be denied and any builds and artifact mirrors that use a Gradle URL with the non-secure HTTP protocol will fail.

from: https://blog.gradle.org/decommissioning-http.  

By simply changing central maven address this problem can be solved. I am not experienced with Gradle or Java, my method might not be optimal (I just simply added another repository).  
I also changed forge maven to https to avoid future errors.  

Edit: I just realized that my editor just decimated indentation, sorry about that. Also realized that this unfortunately is not enough to fix all HTTPS errors, using 'build' task, ForgeGradle still tries to fetch dependencies from an HTTP repo and I don't know how to fix that.